### PR TITLE
MVP terminology adjustment

### DIFF
--- a/gatekeeper/gate_keeper.rb
+++ b/gatekeeper/gate_keeper.rb
@@ -27,27 +27,31 @@ class GateKeeper < Sinatra::Base
     error 401 unless request.env['HTTP_KEY'] == auth_token
   end
 
-  before '/whitelist' do
-    retrieve_input!
+  [ '/whitelist', '/allowlist' ].each do |endpoint|
+    before endpoint do
+      retrieve_input!
+    end
   end
 
   get '/' do
     'What are we adding to the whitelist?'
   end
 
-  post '/whitelist' do
-    user_ip = request_payload['ip']
-    user    = request_payload['username']
-    if user && IPAddress.valid?(user_ip)
-      whitelister.authorize_ip(user_ip, user)
-      logger.info('user ' + user + ' has registered ip: ' + user_ip)
-      content_type :json
-      { status: 200, message: 'success' }.to_json
-    else
-      logger.info('invalid request')
-      content_type :json
-      status 500
-      body({ status: 500, message: 'failure' }.to_json)
+  [ '/whitelist', '/allowlist' ].each do |endpoint|
+    post endpoint do
+      user_ip = request_payload['ip']
+      user    = request_payload['username']
+      if user && IPAddress.valid?(user_ip)
+        whitelister.authorize_ip(user_ip, user)
+        logger.info('user ' + user + ' has registered ip: ' + user_ip)
+        content_type :json
+        { status: 200, message: 'success' }.to_json
+      else
+        logger.info('invalid request')
+        content_type :json
+        status 500
+        body({ status: 500, message: 'failure' }.to_json)
+      end
     end
   end
 

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -11,13 +11,13 @@ class MockGeocoderEntry
 end
 
 describe 'Missing ENV variables' do
-  ['/', '/whitelist/1', '/expire', 'random'].each do |path|
+  ['/', '/whitelist/1', '/allowlist/1', '/expire', 'random'].each do |path|
     it "return an error if GK_SGID is not provided for path #{path}" do
       expect { get path }.to raise_error('GK_SGID must be set')
     end
   end
 
-  ['/', '/whitelist/1', '/expire', 'random'].each do |path|
+  ['/', '/whitelist/1', '/allowlist/1', '/expire', 'random'].each do |path|
     it "return an error if GK_AUTH_TOKEN is not provided for path #{path}" do
       ENV['GK_SGID'] = 'GK_SGID'
       expect { get path }.to raise_error('GK_AUTH_TOKEN must be set')
@@ -37,45 +37,47 @@ describe 'Authorized access without ALLOWED_COUNTRIES' do
     expect(last_response.body).to eq('What are we adding to the whitelist?')
   end
 
-  it 'should return a json obj with status code of 200 and a message if the correct body with a correct ip was posted.' do
-    expect_any_instance_of(Whitelister).to receive(:authorize_ip)
-    post '/whitelist', { 'ip' => '127.0.0.1', 'username' => 'user' }.to_json, 'HTTP_KEY' => 'GK_AUTH_TOKEN'
-    result = JSON.parse(last_response.body)
-    expect(last_response).to be_ok
-    expect(result['status']).to eq(200)
-    expect(result['message']).to eq('success')
-  end
+  [ '/whitelist', '/allowlist' ].each do |path|
+    it "#{path} should return a json obj with status code of 200 and a message if the correct body with a correct ip was posted." do
+      expect_any_instance_of(Whitelister).to receive(:authorize_ip)
+      post path, { 'ip' => '127.0.0.1', 'username' => 'user' }.to_json, 'HTTP_KEY' => 'GK_AUTH_TOKEN'
+      result = JSON.parse(last_response.body)
+      expect(last_response).to be_ok
+      expect(result['status']).to eq(200)
+      expect(result['message']).to eq('success')
+    end
 
-  it 'should return a json obj with status code of 500 and a message if the correct body with an incorrect ip was posted.' do
-    post '/whitelist', { 'ip' => '127.0.0.fff', 'username' => 'user' }.to_json, 'HTTP_KEY' => 'GK_AUTH_TOKEN'
-    result = JSON.parse(last_response.body)
-    expect(last_response.status).to eq(500)
-    expect(result['status']).to eq(500)
-    expect(result['message']).to eq('failure')
-  end
+    it "#{path} should return a json obj with status code of 500 and a message if the correct body with an incorrect ip was posted." do
+      post path, { 'ip' => '127.0.0.fff', 'username' => 'user' }.to_json, 'HTTP_KEY' => 'GK_AUTH_TOKEN'
+      result = JSON.parse(last_response.body)
+      expect(last_response.status).to eq(500)
+      expect(result['status']).to eq(500)
+      expect(result['message']).to eq('failure')
+    end
 
-  it 'should return a json obj with status code of 500 and a message if the body does not exist.' do
-    post '/whitelist', {}.to_json, 'HTTP_KEY' => 'GK_AUTH_TOKEN'
-    result = JSON.parse(last_response.body)
-    expect(last_response.status).to eq(500)
-    expect(result['status']).to eq(500)
-    expect(result['message']).to eq('failure')
-  end
+    it 'should return a json obj with status code of 500 and a message if the body does not exist.' do
+      post '/whitelist', {}.to_json, 'HTTP_KEY' => 'GK_AUTH_TOKEN'
+      result = JSON.parse(last_response.body)
+      expect(last_response.status).to eq(500)
+      expect(result['status']).to eq(500)
+      expect(result['message']).to eq('failure')
+    end
 
-  it 'should return a json obj with status code of 500 and a message if the body does not have the proper values.' do
-    post '/whitelist', { 'not_ip' => '127.0.0.1', 'not_username' => 'user' }.to_json, 'HTTP_KEY' => 'GK_AUTH_TOKEN'
-    result = JSON.parse(last_response.body)
-    expect(last_response.status).to eq(500)
-    expect(result['status']).to eq(500)
-    expect(result['message']).to eq('failure')
-  end
+    it 'should return a json obj with status code of 500 and a message if the body does not have the proper values.' do
+      post '/whitelist', { 'not_ip' => '127.0.0.1', 'not_username' => 'user' }.to_json, 'HTTP_KEY' => 'GK_AUTH_TOKEN'
+      result = JSON.parse(last_response.body)
+      expect(last_response.status).to eq(500)
+      expect(result['status']).to eq(500)
+      expect(result['message']).to eq('failure')
+    end
 
-  it 'should return a json obj with status code of 500 and a message if the IP address is invalid.' do
-    post '/whitelist', { 'ip' => 'Invlaid', 'username' => 'user' }.to_json, 'HTTP_KEY' => 'GK_AUTH_TOKEN'
-    result = JSON.parse(last_response.body)
-    expect(last_response.status).to eq(500)
-    expect(result['status']).to eq(500)
-    expect(result['message']).to eq('failure')
+    it 'should return a json obj with status code of 500 and a message if the IP address is invalid.' do
+      post '/whitelist', { 'ip' => 'Invlaid', 'username' => 'user' }.to_json, 'HTTP_KEY' => 'GK_AUTH_TOKEN'
+      result = JSON.parse(last_response.body)
+      expect(last_response.status).to eq(500)
+      expect(result['status']).to eq(500)
+      expect(result['message']).to eq('failure')
+    end
   end
 end
 


### PR DESCRIPTION
This PR adds an `allowlist/` endpoint that mirrors the `whitelist/` endpoint and is an MVP effort to adjust terminology in related tools.